### PR TITLE
Add Flask-based prompt injection PoC

### DIFF
--- a/prompt_injection_poc/README.md
+++ b/prompt_injection_poc/README.md
@@ -1,0 +1,11 @@
+# Prompt Injection PoC
+
+## Setup
+1. `pip install -r requirements.txt`
+2. `python app.py`
+3. Test endpoints:
+   - `curl -X POST -H 'Content-Type: application/json' -d '{"prompt": "Hello"}' http://localhost:5000/attack`
+   - `curl -X POST -H 'Content-Type: application/json' -d '{"prompt": "Hello"}' http://localhost:5000/safe`
+
+## Description
+Demonstrates a prompt-injection attack and a simple sanitizer.

--- a/prompt_injection_poc/app.py
+++ b/prompt_injection_poc/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+from sanitizer import sanitize
+app = Flask(__name__)
+# Load small GPT-2 model
+tokenizer = AutoTokenizer.from_pretrained('gpt2')
+model = AutoModelForCausalLM.from_pretrained('gpt2')
+model.eval()
+@app.route('/attack', methods=['POST'])
+def attack():
+    data = request.get_json()
+    prompt = data.get('prompt', '')
+    inputs = tokenizer.encode(prompt, return_tensors='pt')
+    outputs = model.generate(inputs, max_length=50)
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return jsonify({'response': text})
+@app.route('/safe', methods=['POST'])
+def safe():
+    data = request.get_json()
+    prompt = data.get('prompt', '')
+    clean_prompt = sanitize(prompt)
+    inputs = tokenizer.encode(clean_prompt, return_tensors='pt')
+    outputs = model.generate(inputs, max_length=50)
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return jsonify({'sanitized_prompt': clean_prompt, 'response': text})
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/prompt_injection_poc/requirements.txt
+++ b/prompt_injection_poc/requirements.txt
@@ -1,0 +1,3 @@
+flask
+transformers
+torch

--- a/prompt_injection_poc/sanitizer.py
+++ b/prompt_injection_poc/sanitizer.py
@@ -1,0 +1,14 @@
+import re
+from typing import List
+BLOCKLIST: List[str] = [
+    r"ignore previous instructions",
+    r"jailbreak",
+]
+def sanitize(prompt: str) -> str:
+    """Remove suspicious phrases from the prompt and log them."""
+    clean = prompt
+    for pattern in BLOCKLIST:
+        if re.search(pattern, clean, flags=re.IGNORECASE):
+            print(f"Blocked phrase detected: {pattern}")
+            clean = re.sub(pattern, "", clean, flags=re.IGNORECASE)
+    return clean.strip()

--- a/prompt_injection_poc/tests/test_sanitizer.py
+++ b/prompt_injection_poc/tests/test_sanitizer.py
@@ -1,0 +1,9 @@
+import unittest
+from prompt_injection_poc.sanitizer import sanitize
+class SanitizerTest(unittest.TestCase):
+    def test_blocklist(self):
+        prompt = 'Please jailbreak this model'
+        sanitized = sanitize(prompt)
+        self.assertNotIn('jailbreak', sanitized.lower())
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create Flask app hosting GPT-2 with attack and safe endpoints
- implement basic sanitizer
- provide install and usage instructions
- add unit test for sanitizer

## Testing
- `python -m unittest discover prompt_injection_poc/tests`

------
https://chatgpt.com/codex/tasks/task_e_684f16a96ed883249f87bc421a77521e